### PR TITLE
fix: adjust mW values to W in ryzenadj.ts

### DIFF
--- a/src/main/ipc-server.ts
+++ b/src/main/ipc-server.ts
@@ -38,7 +38,8 @@ export function setupIpcServer(): Promise<void> {
       )
 
       ipcMain.handle('getSettings', async (): Promise<IpcResponse<AppSettings>> => {
-        logger.info('Client requested current settings state', appState.appSettings)
+        logger.info('Client requested current settings state')
+        logger.debug('Current settings state: ', appState.appSettings)
         return new IpcResponse<AppSettings>(appState.appSettings)
       })
 

--- a/src/main/ryzenadj.ts
+++ b/src/main/ryzenadj.ts
@@ -1,6 +1,7 @@
 import sudo from 'sudo-prompt'
 import { APP_NAME as name } from './config/app-name'
 import { logger } from './config/logger'
+import { RyzenInfoParamsMap, RyzenParamsUnitsMap } from '/@/types/ryzenadj/param-maps'
 import type {
   RyzenInfo,
   RyzenInfoParams,
@@ -54,11 +55,15 @@ export function parseRyzenAdjInfo(output: string): RyzenInfo {
     if (cols.length !== 3) continue
 
     const [name, valueStr, parameter] = cols
+    const key = name.replaceAll(' ', '_')
     let value: number | string = valueStr
     const num = Number(valueStr)
-    if (!isNaN(num)) value = num
+    if (!isNaN(num)) {
+      // values documented as mW are actually reported in W
+      value = RyzenParamsUnitsMap[RyzenInfoParamsMap[key]]?.includes('mW') ? num * 1000 : num
+    }
 
-    result[name.replaceAll(' ', '_')] = { value, ...(parameter !== '' ? { parameter } : {}) }
+    result[key] = { value, ...(parameter !== '' ? { parameter } : {}) }
   }
 
   // not parsed correctly, and also not needed

--- a/src/test/ryzenadj.test.ts
+++ b/src/test/ryzenadj.test.ts
@@ -21,15 +21,15 @@ describe('parseRyzenAdjInfo', () => {
     expect(info['PM_TABLE_VERSION']?.value).toBeTypeOf('string')
 
     const params = new Map<RyzenInfoFields, RyzenInfoValue>([
-      ['STAPM_LIMIT', 45.0],
+      ['STAPM_LIMIT', 45000],
       ['STAPM_VALUE', 8.9],
-      ['PPT_LIMIT_FAST', 65.0],
+      ['PPT_LIMIT_FAST', 65000],
       ['PPT_VALUE_FAST', 11.681],
-      ['PPT_LIMIT_SLOW', 54.0],
+      ['PPT_LIMIT_SLOW', 54000],
       ['PPT_VALUE_SLOW', 11.608],
       ['StapmTimeConst', 275.0],
       ['SlowPPTTimeConst', 5.0],
-      ['PPT_LIMIT_APU', 42.0],
+      ['PPT_LIMIT_APU', 42000],
       ['PPT_VALUE_APU', 11.608],
       ['TDC_LIMIT_VDD', 51.0],
       ['TDC_VALUE_VDD', 6.117],


### PR DESCRIPTION
Values are read in W but input in mW.

Some W values are still passed through unmodified. Until I refactor the parameter metadata data structures (the mappings of keys and names to each other and to descriptions/units) this is going to be the most convenient workaround. It is likely this change will be reverted when that work is done.