### PR TITLE
chore: restructure ryzenInfo params

### DIFF
--- a/src/main/ipc-server.ts
+++ b/src/main/ipc-server.ts
@@ -38,7 +38,8 @@ export function setupIpcServer(): Promise<void> {
       )
 
       ipcMain.handle('getSettings', async (): Promise<IpcResponse<AppSettings>> => {
-        logger.info('Client requested current settings state', appState.appSettings)
+        logger.info('Client requested current settings state')
+        logger.debug('Current settings state: ', appState.appSettings)
         return new IpcResponse<AppSettings>(appState.appSettings)
       })
 

--- a/src/main/ryzenadj.ts
+++ b/src/main/ryzenadj.ts
@@ -1,7 +1,7 @@
 import sudo from 'sudo-prompt'
 import { APP_NAME as name } from './config/app-name'
 import { logger } from './config/logger'
-import { RyzenInfoParamsMap, RyzenParamsUnitsMap } from '/@/types/ryzenadj/param-maps'
+import { RyzenInputKeyNameMap, RyzenNameUnitMap } from '/@/types/ryzenadj/params'
 import type {
   RyzenInfo,
   RyzenInfoParams,
@@ -60,20 +60,20 @@ export function parseRyzenAdjInfo(output: string): RyzenInfo {
     const num = Number(valueStr)
     if (!isNaN(num)) {
       // values documented as mW are actually reported in W
-      value = RyzenParamsUnitsMap[RyzenInfoParamsMap[key]]?.includes('mW') ? num * 1000 : num
+      value = RyzenNameUnitMap[RyzenInputKeyNameMap[key]]?.includes('mW') ? num * 1000 : num
     }
 
     result[key] = { value, ...(parameter !== '' ? { parameter } : {}) }
   }
 
   // not parsed correctly, and also not needed
-  delete result['CCLK_BUSY_VALUE']?.parameter
-  delete result['CCLK_Boost_SETPOINT']?.parameter
+  delete result['CCLK_BUSY_VALUE']?.name
+  delete result['CCLK_Boost_SETPOINT']?.name
 
   if (result['CCLK_Boost_SETPOINT']?.value === 50) {
-    result['POWER_SAVING'] = { value: 'max-performance', parameter: 'power-saving' }
+    result['POWER_SAVING'] = { value: 'max-performance', name: 'power-saving' }
   } else if (result['CCLK_Boost_SETPOINT']?.value === 95) {
-    result['POWER_SAVING'] = { value: 'power-saving', parameter: 'power-saving' }
+    result['POWER_SAVING'] = { value: 'power-saving', name: 'power-saving' }
   }
 
   return result

--- a/src/main/ryzenadj.ts
+++ b/src/main/ryzenadj.ts
@@ -1,6 +1,7 @@
 import sudo from 'sudo-prompt'
 import { APP_NAME as name } from './config/app-name'
 import { logger } from './config/logger'
+import { RyzenInfoParamsMap, RyzenParamsUnitsMap } from '/@/types/ryzenadj/param-maps'
 import type {
   RyzenInfo,
   RyzenInfoParams,
@@ -54,11 +55,15 @@ export function parseRyzenAdjInfo(output: string): RyzenInfo {
     if (cols.length !== 3) continue
 
     const [name, valueStr, parameter] = cols
+    const key = name.replaceAll(' ', '_')
     let value: number | string = valueStr
     const num = Number(valueStr)
-    if (!isNaN(num)) value = num
+    if (!isNaN(num)) {
+      // values documented as mW are actually reported in W
+      value = RyzenParamsUnitsMap[RyzenInfoParamsMap[key]]?.includes('mW') ? num * 1000 : num
+    }
 
-    result[name.replaceAll(' ', '_')] = { value, ...(parameter !== '' ? { parameter } : {}) }
+    result[key] = { value, ...(parameter !== '' ? { parameter } : {}) }
   }
 
   // not parsed correctly, and also not needed

--- a/src/renderer/src/components/RyzenValues.tsx
+++ b/src/renderer/src/components/RyzenValues.tsx
@@ -2,10 +2,10 @@ import { useContext, useEffect, useState } from 'react'
 import InfoTooltip from '/@renderer/components/control/InfoTooltip'
 import { RyzenInfoContext } from '/@renderer/lib/context'
 import {
-  RyzenInfoFieldsMap,
-  RyzenParamsDescriptionMap,
-  RyzenParamsUnitsMap
-} from '/@types/ryzenadj/param-maps'
+  RyzenInputKeyNameMap,
+  RyzenNameUnitMap,
+  RyzenParamsNameDescriptionMap
+} from '/@types/ryzenadj/params'
 
 function populated(obj): boolean {
   return Object.keys(obj).length !== 0
@@ -49,8 +49,8 @@ function RyzenValues(): React.JSX.Element {
                 if (ryzenInfo[key]['parameter']) {
                   return
                 }
-                const desc = RyzenParamsDescriptionMap[RyzenInfoFieldsMap[key]]
-                const unit = RyzenParamsUnitsMap[RyzenInfoFieldsMap[key]]
+                const desc = RyzenParamsNameDescriptionMap[RyzenInputKeyNameMap[key]]
+                const unit = RyzenNameUnitMap[RyzenInputKeyNameMap[key]]
                 return (
                   <tr key={key}>
                     <td className="flex flex-row items-center gap-2">

--- a/src/renderer/src/components/Status.tsx
+++ b/src/renderer/src/components/Status.tsx
@@ -1,7 +1,7 @@
 import { useContext } from 'react'
 import InfoTooltip from '/@renderer/components/control/InfoTooltip'
 import { RyzenInfoContext } from '/@renderer/lib/context'
-import { RyzenParamsDescriptionMap } from '/@types/ryzenadj/param-maps'
+import { RyzenParamsNameDescriptionMap } from '/@types/ryzenadj/params'
 
 function Status({ className = '' }: { className?: string }): React.JSX.Element {
   const ryzenInfo = useContext(RyzenInfoContext)
@@ -28,7 +28,7 @@ function Status({ className = '' }: { className?: string }): React.JSX.Element {
         <div>
           {`${powerStrings[ryzenInfo.POWER_SAVING?.value ?? ''] ?? '-'}`}{' '}
           <InfoTooltip
-            tooltip={RyzenParamsDescriptionMap[ryzenInfo.POWER_SAVING?.value ?? '']}
+            tooltip={RyzenParamsNameDescriptionMap[ryzenInfo.POWER_SAVING?.value ?? '']}
             className="relative top-[2px] h-3 w-3"
             direction="left"
           />

--- a/src/test/ryzenadj.test.ts
+++ b/src/test/ryzenadj.test.ts
@@ -3,9 +3,9 @@ import '/@test/mocks/setup-mocks.ts'
 import fs from 'fs'
 import path from 'path'
 import { describe, expect, it } from 'vitest'
+import { RyzenInputKeyNameMap } from '../types/ryzenadj/params'
 import { parseRyzenAdjInfo } from '/@/main/ryzenadj'
-import type { RyzenInfoFields, RyzenInfoValue } from '/@/types/ryzenadj/ryzenadj'
-import { RyzenInfoParamsMap } from '/@types/ryzenadj/param-maps'
+import type { RyzenInfoKeys, RyzenInfoValue } from '/@/types/ryzenadj/ryzenadj'
 
 describe('parseRyzenAdjInfo', () => {
   it('parses ryzenadj -i output correctly', () => {
@@ -20,7 +20,7 @@ describe('parseRyzenAdjInfo', () => {
     expect(info['PM_TABLE_VERSION']?.value).toBe('400005')
     expect(info['PM_TABLE_VERSION']?.value).toBeTypeOf('string')
 
-    const params = new Map<RyzenInfoFields, RyzenInfoValue>([
+    const params = new Map<RyzenInfoKeys, RyzenInfoValue>([
       ['STAPM_LIMIT', 45000],
       ['STAPM_VALUE', 8.9],
       ['PPT_LIMIT_FAST', 65000],
@@ -52,8 +52,8 @@ describe('parseRyzenAdjInfo', () => {
     for (const key of params.keys()) {
       expect(info[key]?.value).toBe(params.get(key))
       expect(info[key]?.value).toBeTypeOf(typeof params.get(key))
-      if (info[key]?.parameter) {
-        expect(info[key]?.parameter).toBe(RyzenInfoParamsMap[key])
+      if (info[key]?.name) {
+        expect(info[key]?.name).toBe(RyzenInputKeyNameMap[key])
       }
     }
   })

--- a/src/test/ryzenadj.test.ts
+++ b/src/test/ryzenadj.test.ts
@@ -21,15 +21,15 @@ describe('parseRyzenAdjInfo', () => {
     expect(info['PM_TABLE_VERSION']?.value).toBeTypeOf('string')
 
     const params = new Map<RyzenInfoFields, RyzenInfoValue>([
-      ['STAPM_LIMIT', 45.0],
+      ['STAPM_LIMIT', 45000],
       ['STAPM_VALUE', 8.9],
-      ['PPT_LIMIT_FAST', 65.0],
+      ['PPT_LIMIT_FAST', 65000],
       ['PPT_VALUE_FAST', 11.681],
-      ['PPT_LIMIT_SLOW', 54.0],
+      ['PPT_LIMIT_SLOW', 54000],
       ['PPT_VALUE_SLOW', 11.608],
       ['StapmTimeConst', 275.0],
       ['SlowPPTTimeConst', 5.0],
-      ['PPT_LIMIT_APU', 42.0],
+      ['PPT_LIMIT_APU', 42000],
       ['PPT_VALUE_APU', 11.608],
       ['TDC_LIMIT_VDD', 51.0],
       ['TDC_VALUE_VDD', 6.117],

--- a/src/types/ryzenadj/params.ts
+++ b/src/types/ryzenadj/params.ts
@@ -1,6 +1,90 @@
-import { RyzenInfoFields, RyzenInputParams } from './ryzenadj'
+import { RyzenInfoKeys, RyzenInfoNames } from './ryzenadj'
 
-export const RyzenInfoParamsMap: Partial<Record<RyzenInfoFields, RyzenInputParams>> = {
+// [ ] TODO: These consts and their usages have gotten somewhat messy.
+// just see things like swapKeysAndValues, getKeyFromValue... not great
+// need to figure out a proper data structure for these.
+// Probably a `RyzenInfoField` class which has a readKey, writeKey, name, desc, unit...
+export const RyzenInfoKeysList = [
+  'CPU_FAMILY',
+  'SMU_BIOS',
+  'RYZENADJ_VERSION',
+  'PM_TABLE_VERSION',
+  'STAPM_LIMIT',
+  'STAPM_VALUE',
+  'PPT_LIMIT_FAST',
+  'PPT_VALUE_FAST',
+  'PPT_LIMIT_SLOW',
+  'PPT_VALUE_SLOW',
+  'StapmTimeConst',
+  'SlowPPTTimeConst',
+  'PPT_LIMIT_APU',
+  'PPT_VALUE_APU',
+  'TDC_LIMIT_VDD',
+  'TDC_VALUE_VDD',
+  'TDC_LIMIT_SOC',
+  'TDC_VALUE_SOC',
+  'EDC_LIMIT_VDD',
+  'EDC_VALUE_VDD',
+  'EDC_LIMIT_SOC',
+  'EDC_VALUE_SOC',
+  'THM_LIMIT_CORE',
+  'THM_VALUE_CORE',
+  'STT_LIMIT_APU',
+  'STT_VALUE_APU',
+  'STT_LIMIT_dGPU',
+  'STT_VALUE_dGPU',
+  'CCLK_Boost_SETPOINT',
+  'CCLK_BUSY_VALUE',
+  'POWER_SAVING',
+  'MAX_PERFORMANCE'
+] as const
+
+export const RyzenInfoNamesList = [
+  'stapm-limit',
+  'fast-limit',
+  'slow-limit',
+  'slow-time',
+  'stapm-time',
+  'tctl-temp',
+  'vrm-current',
+  'vrmsoc-current',
+  'vrmgfx-current',
+  'vrmcvip-current',
+  'vrmmax-current',
+  'vrmsocmax-current',
+  'vrmgfxmax_current',
+  'psi0-current',
+  'psi3cpu_current',
+  'psi0soc-current',
+  'psi3gfx_current',
+  'max-socclk-frequency',
+  'min-socclk-frequency',
+  'max-fclk-frequency',
+  'min-fclk-frequency',
+  'max-vcn',
+  'min-vcn',
+  'max-lclk',
+  'min-lclk',
+  'max-gfxclk',
+  'min-gfxclk',
+  'prochot-deassertion-ramp',
+  'apu-skin-temp',
+  'dgpu-skin-temp',
+  'apu-slow-limit',
+  'skin-temp-limit',
+  'gfx-clk',
+  'oc-clk',
+  'oc-volt',
+  'enable-oc',
+  'disable-oc',
+  'set-coall',
+  'set-coper',
+  'set-cogfx',
+  'power-saving',
+  'max-performance'
+] as const
+
+export const RyzenInputKeyNameMap: Partial<Record<RyzenInfoKeys, RyzenInfoNames>> = {
   STAPM_LIMIT: 'stapm-limit',
   PPT_LIMIT_FAST: 'fast-limit',
   PPT_LIMIT_SLOW: 'slow-limit',
@@ -18,25 +102,7 @@ export const RyzenInfoParamsMap: Partial<Record<RyzenInfoFields, RyzenInputParam
   MAX_PERFORMANCE: 'max-performance'
 } as const
 
-export const RyzenInfoFieldsMap: Partial<Record<RyzenInfoFields, RyzenInputParams>> = {
-  STAPM_VALUE: 'stapm-limit',
-  PPT_VALUE_FAST: 'fast-limit',
-  PPT_VALUE_SLOW: 'slow-limit',
-  StapmTimeConst: 'stapm-time',
-  SlowPPTTimeConst: 'slow-time',
-  PPT_VALUE_APU: 'apu-slow-limit',
-  TDC_VALUE_VDD: 'vrm-current',
-  TDC_VALUE_SOC: 'vrmsoc-current',
-  EDC_VALUE_VDD: 'vrmmax-current',
-  EDC_VALUE_SOC: 'vrmsocmax-current',
-  THM_VALUE_CORE: 'tctl-temp',
-  STT_VALUE_APU: 'apu-skin-temp',
-  STT_VALUE_dGPU: 'dgpu-skin-temp',
-  POWER_SAVING: 'power-saving',
-  MAX_PERFORMANCE: 'max-performance'
-} as const
-
-export const RyzenParamsDescriptionMap: Record<RyzenInputParams, string> = {
+export const RyzenParamsNameDescriptionMap: Record<RyzenInfoNames, string> = {
   'stapm-limit': 'Sustained Power Limit (mW)',
   'fast-limit': 'Actual Power Limit (mW)',
   'slow-limit': 'Average Power Limit (mW)',
@@ -81,7 +147,7 @@ export const RyzenParamsDescriptionMap: Record<RyzenInputParams, string> = {
   'max-performance': 'Hidden options to improve max performance'
 }
 
-export const RyzenParamsUnitsMap: Partial<Record<RyzenInputParams, string>> = {
+export const RyzenNameUnitMap: Partial<Record<RyzenInfoNames, string>> = {
   'stapm-limit': 'mW',
   'fast-limit': 'mW',
   'slow-limit': 'mW',

--- a/src/types/ryzenadj/ryzenadj.d.ts
+++ b/src/types/ryzenadj/ryzenadj.d.ts
@@ -1,89 +1,15 @@
-import { RyzenInfoParamsMap } from './param-maps'
+import { RyzenInputKeyNameMap, type RyzenInfoKeysList, type RyzenInfoNamesList } from './params'
 
-export type RyzenInfoFields =
-  | 'CPU_FAMILY'
-  | 'SMU_BIOS'
-  | 'RYZENADJ_VERSION'
-  | 'PM_TABLE_VERSION'
-  | 'STAPM_LIMIT'
-  | 'STAPM_VALUE'
-  | 'PPT_LIMIT_FAST'
-  | 'PPT_VALUE_FAST'
-  | 'PPT_LIMIT_SLOW'
-  | 'PPT_VALUE_SLOW'
-  | 'StapmTimeConst'
-  | 'SlowPPTTimeConst'
-  | 'PPT_LIMIT_APU'
-  | 'PPT_VALUE_APU'
-  | 'TDC_LIMIT_VDD'
-  | 'TDC_VALUE_VDD'
-  | 'TDC_LIMIT_SOC'
-  | 'TDC_VALUE_SOC'
-  | 'EDC_LIMIT_VDD'
-  | 'EDC_VALUE_VDD'
-  | 'EDC_LIMIT_SOC'
-  | 'EDC_VALUE_SOC'
-  | 'THM_LIMIT_CORE'
-  | 'THM_VALUE_CORE'
-  | 'STT_LIMIT_APU'
-  | 'STT_VALUE_APU'
-  | 'STT_LIMIT_dGPU'
-  | 'STT_VALUE_dGPU'
-  | 'CCLK_Boost_SETPOINT'
-  | 'CCLK_BUSY_VALUE'
-  | 'POWER_SAVING'
-  | 'MAX_PERFORMANCE'
+export type RyzenInfoKeys = (typeof RyzenInfoKeysList)[number]
 
-export type RyzenInfoKeys = keyof typeof RyzenInfoParamsMap
-export type RyzenInfoParams = (typeof RyzenInfoParamsMap)[RyzenInfoKeys]
+export type RyzenInfoNameMappedKey = keyof typeof RyzenInputKeyNameMap
+export type RyzenInfoParams = (typeof RyzenInputKeyNameMap)[RyzenInfoKeys]
 export type RyzenInfoValue = number | string | null
 
 export type RyzenInfo = Partial<
-  Record<RyzenInfoFields, { value: RyzenInfoValue; parameter?: RyzenInfoParams }>
+  Record<RyzenInfoKeys, { value: RyzenInfoValue; name?: RyzenInfoParams }>
 >
 
 export type RyzenSetResultAndNewInfo = { setResult: boolean; newInfo: RyzenInfo }
 
-export type RyzenInputParams =
-  | 'stapm-limit'
-  | 'fast-limit'
-  | 'slow-limit'
-  | 'slow-time'
-  | 'stapm-time'
-  | 'tctl-temp'
-  | 'vrm-current'
-  | 'vrmsoc-current'
-  | 'vrmgfx-current'
-  | 'vrmcvip-current'
-  | 'vrmmax-current'
-  | 'vrmsocmax-current'
-  | 'vrmgfxmax_current'
-  | 'psi0-current'
-  | 'psi3cpu_current'
-  | 'psi0soc-current'
-  | 'psi3gfx_current'
-  | 'max-socclk-frequency'
-  | 'min-socclk-frequency'
-  | 'max-fclk-frequency'
-  | 'min-fclk-frequency'
-  | 'max-vcn'
-  | 'min-vcn'
-  | 'max-lclk'
-  | 'min-lclk'
-  | 'max-gfxclk'
-  | 'min-gfxclk'
-  | 'prochot-deassertion-ramp'
-  | 'apu-skin-temp'
-  | 'dgpu-skin-temp'
-  | 'apu-slow-limit'
-  | 'skin-temp-limit'
-  | 'gfx-clk'
-  | 'oc-clk'
-  | 'oc-volt'
-  | 'enable-oc'
-  | 'disable-oc'
-  | 'set-coall'
-  | 'set-coper'
-  | 'set-cogfx'
-  | 'power-saving'
-  | 'max-performance'
+export type RyzenInfoNames = (typeof RyzenInfoNamesList)[number]


### PR DESCRIPTION
Try to make distinctions a little clearer: 

- `RyzenInfoKeys`: the ALL_CAPS data field keys displayed by `ryzenadj -i`
- `RyzenInfoNames`: the lower-case name used to set ryzenadj parameters e.g. `ryzenadj --$NAME $VALUE`
- `RyzenInputKeyNameMap`: maps Keys to Names, for the small set of Keys which map to Inputs
- `RyzenInfoParams`: Names which map to a Key (subset of Names which exists as values in RyzenInputKeyNameMap)
