### PR TITLE
fix: restore eslint functionality after broken config caused silent failures

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,6 +1,6 @@
 import eslintConfigPrettier from '@electron-toolkit/eslint-config-prettier'
 import tseslint from '@electron-toolkit/eslint-config-ts'
-import js from '@eslint/js'
+import eslint from '@eslint/js'
 import eslintPluginJsxA11y from 'eslint-plugin-jsx-a11y'
 import eslintPluginReact from 'eslint-plugin-react'
 import eslintPluginReactHooks from 'eslint-plugin-react-hooks'
@@ -9,9 +9,17 @@ import globals from 'globals'
 
 export default tseslint.config(
   { ignores: ['**/node_modules', '**/dist', '**/out'] },
-  { ...tseslint.configs.recommended, files: ['**/*.{ts,tsx}'] },
-  { files: ['**/*.{js,jsx}'], languageOptions: { globals: globals.browser } },
-  { files: ['**/*.{js,jsx}'], plugins: { js }, extends: ['js/recommended'] },
+  eslint.configs.recommended,
+  tseslint.configs.recommended,
+  {
+    files: ['**/*.{js,jsx}'],
+    rules: {
+      '@typescript-eslint/explicit-function-return-type': 'off'
+    },
+    languageOptions: {
+      globals: globals.browser
+    }
+  },
   eslintPluginReact.configs.flat.recommended,
   eslintPluginReact.configs.flat['jsx-runtime'],
   {
@@ -19,17 +27,8 @@ export default tseslint.config(
       react: {
         version: 'detect'
       }
-    }
-  },
-  {
-    files: ['**/*.{ts,tsx}'],
-    plugins: {
-      'react-hooks': eslintPluginReactHooks,
-      'react-refresh': eslintPluginReactRefresh
     },
     rules: {
-      ...eslintPluginReactHooks.configs.recommended.rules,
-      ...eslintPluginReactRefresh.configs.vite.rules,
       ...{
         '@typescript-eslint/no-unused-vars': [
           'error',
@@ -43,7 +42,18 @@ export default tseslint.config(
             ignoreRestSiblings: true
           }
         ]
-      },
+      }
+    }
+  },
+  {
+    files: ['**/*.{ts,tsx}'],
+    plugins: {
+      'react-hooks': eslintPluginReactHooks,
+      'react-refresh': eslintPluginReactRefresh
+    },
+    rules: {
+      ...eslintPluginReactHooks.configs.recommended.rules,
+      ...eslintPluginReactRefresh.configs.vite.rules,
       ...{
         '@typescript-eslint/no-explicit-any': ['off']
       }

--- a/src/renderer/src/components/Settings.tsx
+++ b/src/renderer/src/components/Settings.tsx
@@ -88,7 +88,12 @@ function Settings(): React.JSX.Element {
                 <div role="alert" className="alert alert-info">
                   <span>
                     You can use any valid DaisyUI theme.{' '}
-                    <a className="link" href="https://daisyui.com/theme-generator" target="_blank">
+                    <a
+                      className="link"
+                      href="https://daisyui.com/theme-generator"
+                      target="_blank"
+                      rel="noreferrer"
+                    >
                       The DaisyUI Theme Generator
                     </a>{' '}
                     can generate CSS for you to paste below.
@@ -106,7 +111,7 @@ function Settings(): React.JSX.Element {
                       setValidationError('')
                       setCurrentSettings(await ipc.setSetting('customCss', rawCss))
                     } catch (error) {
-                      // @ts-ignore
+                      // @ts-ignore untyped library will pass us a { message: string }
                       setValidationError(error.message)
                     }
                   }}

--- a/src/renderer/src/components/control/ThemeController.tsx
+++ b/src/renderer/src/components/control/ThemeController.tsx
@@ -16,7 +16,6 @@ function ThemeController(): React.JSX.Element {
     if (themeController.current) {
       setTheme(themeController.current, settings)
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [settings])
 
   useEffect(() => {

--- a/src/renderer/src/lib/theme/theme.ts
+++ b/src/renderer/src/lib/theme/theme.ts
@@ -18,7 +18,7 @@ export function setTheme(themeController: HTMLInputElement, settings: Partial<Ap
     } else {
       rootElem.style = ''
     }
-  } catch (error) {
+  } catch (_error) {
     // swallow error, fall back to other settings
   }
   const systemDark = matchMedia('(prefers-color-scheme: dark)').matches


### PR DESCRIPTION
VSCode didn't tell me that ESLint was broken, and I don't run the linter manually from the CLI to notice.

Might set up CI for that purpose actually. 